### PR TITLE
Add Windows (host) IP to hosts file + fix install for AD accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 > Take a look at https://github.com/shayne/wsl2-hacks for things like auto-starting services, running commands when the VM boots and making localhost ports accessible
 
-A workaround for accessing the WSL2 VM from the Windows host.
+A workaround for accessing the WSL2 VM from the Windows host and vice versa.
 
 This program installs as a service and runs under the local user account. It automatically updates your Windows hosts file with the WSL2 VM's IP address.
 
-The program uses the hostname `wsl.local`
+The program uses the hostname `wsl.local` for the WSL VM and `windows.local` for the Windows host.
 
 I wrote this for my own use but thought it might be useful for others. It's not perfect but gets the job done for me.
 

--- a/install.go
+++ b/install.go
@@ -58,7 +58,9 @@ func installService(name, desc string) error {
 	fmt.Printf("Windows Username: ")
 	var username string
 	fmt.Scanln(&username)
-	username = fmt.Sprintf(".\\%s", strings.TrimSpace(username))
+	if !strings.Contains(username, "\\") && !strings.Contains(username, "@") {
+		username = fmt.Sprintf(".\\%s", strings.TrimSpace(username))
+	}
 	fmt.Printf("Windows Password: ")
 	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {

--- a/pkg/wslcli/wslcli.go
+++ b/pkg/wslcli/wslcli.go
@@ -3,6 +3,7 @@ package wslcli
 import (
 	"errors"
 	"os/exec"
+	"regexp"
 	"strings"
 )
 
@@ -16,8 +17,8 @@ func Running() (bool, error) {
 	return len(out) != 0, nil
 }
 
-// IP returns the IP address of the running default WSL distro
-func IP() (string, error) {
+// GetWslIP returns the IP address of the running default WSL distro
+func GetWslIP() (string, error) {
 	cmd := exec.Command("wsl.exe", "--", "hostname", "-I")
 	out, err := cmd.Output()
 	if err != nil {
@@ -29,4 +30,19 @@ func IP() (string, error) {
 		return "", errors.New("invalid output from hostname -I")
 	}
 	return ips[0], nil
+}
+
+// GetHostIP returns the IP address of Hyper-V Switch on the host connected to WSL
+func GetHostIP() (string, error) {
+	cmd := exec.Command("netsh", "interface", "ip", "show", "address", "vEthernet (WSL)") //, "|", "findstr", "IP Address", "|", "%", "{", "$_", "-replace", "IP Address:", "", "}", "|", "%", "{", "$_", "-replace", " ", "", "}")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	ipRegex := regexp.MustCompile("IP Address:\040*(.*)\r\n")
+	ipString := ipRegex.FindStringSubmatch(string(out))
+	if len(ipString) != 2 {
+		return "", errors.New(`netsh interface ip show address "vEthernet (WSL)"`)
+	}
+	return ipString[1], nil
 }


### PR DESCRIPTION
### 1. Add Windows (host) IP to hosts file
Additionally to making the WSL VM accessible under a static name from the Windows host, implement the same vice versa

### 2. Fix install for AD accounts
Automatic pre-pending of ".\\" before the account name breaks service logon for AD accounts. Changed to only prepending it when no "\\" or "@" was found in the username.


Big fat thanks @shayne for idea and implementation of this utility!