### PR TITLE
Modify the method of getting ip and host alias

### DIFF
--- a/.wsl2hosts
+++ b/.wsl2hosts
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+# Put this script to `~/.wsl2hosts` and `chmod +x ~/.wsl2hosts`
+
+# This line will print your WSL2 VM's IP address.
+# Default:
+# echo $(hostname -I)
+
+# Command `hostname -I` is not available in some cases, you can change the command to your own.
+# For example:`
+# echo $(ip addr show eth0 | grep 'inet\s' | awk '{print $2}' | awk -F '/' '{print $1}')
+
+echo $(hostname -I)
+
+# ---------------------------------------------------------------------------------------------
+
+# This line will print your WSL2 VM's hostname and will be used in Windows's hosts file.
+# Default:
+# echo ""
+
+# By set to empty, hostname will be generated automatically, but you can set your own hostname.
+# For example:`
+# echo "wsl.vm wsl.local"
+
+echo ""

--- a/README.md
+++ b/README.md
@@ -40,8 +40,22 @@ Open an **elevated/administrator** command prompt:
 
 As of v0.3 you can no specify aliases that point to your WSL2 VM IP. Having `some.client.local`, may be useful in your development workflow.
 
-To do this, create the file `~/.wsl2hosts` in your default WSL2 distro. Host names are space separated:
+To do this, download the script `.wsl2hosts` of this project in your default WSL2 distro, put it in `~/.wsl2hosts` and set it executable. Modify the script at line 25 to your own alias.
+
+Host names are space separated:
+
 ```
-some.client.local my-app.local wsl.local
+echo "some.client.local my-app.local wsl.local"
 ```
 
+**Specifying custom command to get IP**
+
+Default method of getting VM's IP address is to run `hostname -I` command. If command `hostname -I` is not available in some cases, you can change the command to your own.
+
+To do this, download the script `.wsl2hosts` of this project in your default WSL2 distro, put it in `~/.wsl2hosts` and set it executable. Modify the script at line 13 to your own command.
+
+For example:
+
+```
+echo $(ip addr show eth0 | grep 'inet\s' | awk '{print $2}' | awk -F '/' '{print $1}')
+```


### PR DESCRIPTION
Command `hostname -I` is not available to get VM's IP address in some cases, e.g in Arch Linux, so I did something to let user set custom command. For the reason that `~/.wsl2hosts` was already used to set custom host alias, I combined these. 
Now we can set custom command and custom host alias in one file.