### PR TITLE
WSL 1 IP always 127.0.0.1 & use "LocalSystem" to run service

### DIFF
--- a/cmd/wsl2host/internal/install.go
+++ b/cmd/wsl2host/internal/install.go
@@ -6,10 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-	"syscall"
 
-	"golang.org/x/crypto/ssh/terminal"
 	"golang.org/x/sys/windows/svc/eventlog"
 	"golang.org/x/sys/windows/svc/mgr"
 )
@@ -56,19 +53,7 @@ func InstallService(name, desc string) error {
 		s.Close()
 		return fmt.Errorf("service %s already exists", name)
 	}
-	fmt.Printf("Windows Username: ")
-	var username string
-	fmt.Scanln(&username)
-	if !strings.Contains(username, "\\") && !strings.Contains(username, "@") {
-		username = fmt.Sprintf(".\\%s", strings.TrimSpace(username))
-	}
-	fmt.Printf("Windows Password: ")
-	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
-	if err != nil {
-		return err
-	}
-	password := strings.TrimSpace(string(bytePassword))
-	s, err = m.CreateService(name, exepath, mgr.Config{DisplayName: desc, StartType: mgr.StartAutomatic, ServiceStartName: username, Password: password}, "is", "auto-started")
+	s, err = m.CreateService(name, exepath, mgr.Config{DisplayName: desc, StartType: mgr.StartAutomatic, ServiceStartName: "LocalSystem"}, "is", "auto-started")
 	if err != nil {
 		return err
 	}

--- a/cmd/wsl2host/pkg/service/service.go
+++ b/cmd/wsl2host/pkg/service/service.go
@@ -54,10 +54,15 @@ func Run(elog debug.Log) error {
 		}
 
 		// update IPs of running distros
-		ip, err := wslapi.GetIP(i.Name)
-		if err != nil {
-			elog.Info(1, fmt.Sprintf("failed to get IP for distro %q: %v", i.Name, err))
-			continue
+		var ip string
+		if i.Version == 1 {
+			ip = "127.0.0.1"
+		} else {
+			ip, err = wslapi.GetIP(i.Name)
+			if err != nil {
+				elog.Info(1, fmt.Sprintf("failed to get IP for distro %q: %v", i.Name, err))
+				continue
+			}
 		}
 		if he, exists := hostentries[hostname]; exists {
 			if he.IP != ip {


### PR DESCRIPTION
我做了两个修改，一个是 WSL 1 直接使用`127.0.0.1`作为其IP地址，另一个是使用`本地服务`来运行，而不是输入用户名密码。
I made two changes, one is using `127.0.0.1` as WSL 1's IP , and the other is to use `LocalSystem` to run instead of entering the username and password.
我的电脑上同时使用了WSL的两种版本，但是在WSL 1下并没有`/proc/net/fib_trie`文件，从而导致程序报错，无法运行。因此在获得IP的时候先判断WSL的版本，如果是WSL 1 则直接设置为`127.0.0.1`。
I use both versions of WSL on my computer. There is no `/proc/net/fib_trie` file under WSL 1, which causes the program to report errors and fail to run. Therefore, when obtaining the IP, first determine the version of WSL. If it is WSL 1, set it's IP as `127.0.0.1`.
我发现并不需要输入用户自己的用户名密码，而且输入的用户名密码还存在会输入错误的情况，同时Windows服务可以使用本地服务的形式安装，所以去掉多余的部分，直接使用`本地服务`来安装服务并运行。
I found that it is not necessary to input username and password, and those may also be wrong. So remove the extra parts and use `LocalSystem` to install the service and run it.