### PR TITLE
Change to restart IP helper service (iphlpsvc) for port forwarding

### DIFF
--- a/cmd/wsl2host/pkg/service/service.go
+++ b/cmd/wsl2host/pkg/service/service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"os/exec"
 
 	"github.com/shayne/go-wsl2-host/internal/wsl2hosts"
 	"golang.org/x/sys/windows/svc/debug"
@@ -138,6 +139,10 @@ func Run(elog debug.Log) error {
 			elog.Error(1, fmt.Sprintf("failed to write hosts file: %v", err))
 			return fmt.Errorf("failed to write hosts file: %w", err)
 		}
+
+		// restart the IP Helper service (iphlpsvc) for port forwarding
+		exec.Command("C:\\Windows\\System32\\cmd.exe", "/C net stop  iphlpsvc").Run()
+		exec.Command("C:\\Windows\\System32\\cmd.exe", "/C net start iphlpsvc").Run()
 	}
 
 	return nil


### PR DESCRIPTION
I wanted to access the web server or SSH server in WSL2 from another PC on my local network. However, you need port forwarding (netsh interface portproxy) to do that, and you need to specify an IP address to configure port forwarding.
As you know, the IP address of WSL2 changes frequently, so until now you had to reconfigure port forwarding every time the IP address of WSL changed.

So I found this go-wsl2-host and decided to set ubuntu.wsl instead of IP in the port forwarding settings to save the trouble of reconfiguring.
However, I found that the IP address where port forwarding actually takes place does not switch unless the Windows service that does port forwarding, IP Helper (iphlpsvc), is restarted.
In other words, in order to be freed from the port forwarding reconfiguration that occurs every time the WSL2 IP address changes, after go-wsl2-host detects his WSL2 IP address change and rewrites the hosts file, the IP Helper The service had to be restarted.

This pull request modifies the IP helper service for port forwarding (iphlpsvc) to restart after it detects a change in the WSL2 IP address and finishes rewriting hosts.
With this change, by using the ubuntu.wsl local domain, we no longer have to worry about resetting the WSL2 IP address. This practically solves the problem of frequent WSL2 IP address resets.

Since this is my first time using Golang, the code may not be good.
I'm Japanese and use Google Translate. The text may be unnatural.