### PR TITLE
Fix: Support host.wsl for non-English OS

### DIFF
--- a/pkg/wslcli/wslcli.go
+++ b/pkg/wslcli/wslcli.go
@@ -190,12 +190,12 @@ func GetHostIP() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ipRegex := regexp.MustCompile("IP Address:\040*(.*)\r\n")
+	ipRegex := regexp.MustCompile("IP(.*):\040*(.*)\r\n")
 	ipString := ipRegex.FindStringSubmatch(string(out))
-	if len(ipString) != 2 {
+	if len(ipString) != 3 {
 		return "", errors.New(`netsh interface ip show address "vEthernet (WSL)"`)
 	}
-	return ipString[1], nil
+	return ipString[2], nil
 }
 
 func decodeOutput(raw []byte) (string, error) {


### PR DESCRIPTION
This is command  (`netsh interface ip show address "vEthernet (WSL)"`) stdout for chinese language. 
![image](https://user-images.githubusercontent.com/21984442/147721728-9beb85b9-b58a-4080-874a-6b4fc5d36575.png)