### PR TITLE
Fix GetHostIP regular expression

### DIFF
--- a/pkg/hostsapi/hostsapi.go
+++ b/pkg/hostsapi/hostsapi.go
@@ -201,7 +201,7 @@ func GetHostIP() (string, error) {
 	}
 	// If system language not english, the output not "IP Address". such as in chinese it's "IP 地址".
 	// And the output no have other such as "IP", so we can only match the "IP".
-	ipRegex := regexp.MustCompile("IP .*:\040*(.*)\r\n")
+	ipRegex := regexp.MustCompile("IP.*:?\040*(.*)\r\n")
 	ipString := ipRegex.FindStringSubmatch(string(out))
 	if len(ipString) != 2 {
 		return "", errors.New(`netsh interface ip show address "vEthernet (WSL)"`)


### PR DESCRIPTION
Hello! There is an issue with host ip detection in non-english locales. In my env I have netsh output in the following format:
"IP-xxx               xxx.xxx.xxx.xxx"
There is not space after IP, and there is no colon.