### PR TITLE
Support using default local service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ To install and run, download a binary from the releases tab. Place it somewhere 
 
 Open an **elevated/administrator** command prompt:
 
-```
+```powershell
 > .\wsl2host.exe install
-Windows Username: <username-you-use-to-login-to-windows>
-Windows Password: <password-for-this-user>
+Windows Username: NT AUTHORITY\LocalService
+Windows Password: <just press enter for empty password if you plan to install and run as LocalService>
 ```
 
-The program will install a service and start it up. 
+The program will install a service and start it up.
 
-The user account informed must have the right to `logon on as a service`. To do so, run `secpol.msc` command and navigate to `Security Settings - Local policies - User rights assignment > Log on as a service`, and add your username.
+If you don't use the default local service account `NT Authority\Local Service`, the user account informed must have the right to `logon on as a service`. To do so, run `secpol.msc` command and navigate to `Security Settings - Local policies - User rights assignment > Log on as a service`, and add your username.
 
 Launch `wsl` then from a `cmd` prompt, run `ping ubuntu1804.wsl`. You can check the Windows hosts file to see what was written. The service will automatically update the IP if the WSL2 VM is stopped and started again.
 
@@ -38,16 +38,16 @@ _NOTE: Upgrading Windows Insider will remove the service, but not cleanly. To re
 
 Open an **elevated/administrator** command prompt:
 
-```
+```powershell
 > .\wsl2host.exe remove
 ```
 
-**Specifying aliases**
+**Specifying aliases:**
 
 As of v0.3 you can now specify aliases that point to your WSL2 VM IP. Having `some.client.local`, may be useful in your development workflow.
 
 To do this, create the file `~/.wsl2hosts` in your default WSL2 distro. Host names are space separated:
-```
+
+```text
 some.client.local my-app.local wsl.local
 ```
-

--- a/cmd/wsl2host/internal/install.go
+++ b/cmd/wsl2host/internal/install.go
@@ -1,8 +1,10 @@
+//go:build windows
 // +build windows
 
 package internal
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -58,7 +60,10 @@ func InstallService(name, desc string) error {
 	}
 	fmt.Printf("Windows Username: ")
 	var username string
-	fmt.Scanln(&username)
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		username = scanner.Text()
+	}
 	if !strings.Contains(username, "\\") && !strings.Contains(username, "@") {
 		username = fmt.Sprintf(".\\%s", strings.TrimSpace(username))
 	}


### PR DESCRIPTION
There is a default service account `NT AUTHORITY\LocalService` we can use to install the wsl2host service.
However, `fmt` does not support taking user input with space in it.

With this change, I am able to enter user name `NT AUTHORITY\LocalService` and no passowrd (just press enter  on password prompt), and have the service up and running.

![image](https://user-images.githubusercontent.com/831085/230730218-e0086de7-1388-481b-91cd-100423c1433b.png)
