### PR TITLE
fix: proper error when default distro is not found

### DIFF
--- a/cmd/wsl2host/pkg/service/service.go
+++ b/cmd/wsl2host/pkg/service/service.go
@@ -100,7 +100,7 @@ func updateHostIP(elog debug.Log, distros []*wslapi.DistroInfo) error {
 	}
 
 	// process aliases
-	defdistro, _ := wslapi.GetDefaultDistro()
+	defdistro, err := wslapi.GetDefaultDistro()
 	if err != nil {
 		elog.Error(1, fmt.Sprintf("GetDefaultDistro failed: %v", err))
 		return fmt.Errorf("GetDefaultDistro failed: %w", err)


### PR DESCRIPTION
The error should not be discarded.
Probably fixed (or will help fixing) #80 
My default distro was set to  `docker-desktop-data`, and `panic: runtime error: invalid memory address or nil pointer dereference` was showing (exactly the same as in the issue).